### PR TITLE
Added support for shell environment variables

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ keysOptional = ['prefix', 'postfix']
 
 def importkey(name, optional=False):
     key = name
+    envKey = key.replace("-", "_")
 
     secretPath = "/run/secrets/"+key
     if (os.path.isfile(secretPath)):
@@ -16,6 +17,8 @@ def importkey(name, optional=False):
         return out
     elif (key in os.environ):
         return os.environ.get(key)
+    elif (envKey in os.environ):
+        return os.environ.get(envKey)
     else:
         try:
             cfgPath = os.path.dirname(os.path.realpath(__file__))+'/config.ini'


### PR DESCRIPTION
Currently the environment variables have hyphens that can't be used in
some environments (e.g., sourcing in a shell or using EnvironmentFile
in systemd).  This adds an additional check to see if the a variant with
an underscore ("_") instead of a hyphen ("-") is present.