### PR TITLE
Replace spaces in hostnames with dashes

### DIFF
--- a/app/tailscale.py
+++ b/app/tailscale.py
@@ -50,7 +50,11 @@ def alterHostname(hostname):
     pre = config.get("prefix", "")
     post = config.get("postfix", "")
 
-    newHostname = "{pre}{hostname}{post}".format(pre=pre, post=post, hostname=hostname)
+    newHostname = "{pre}{hostname}{post}".format(
+        pre=pre,
+        post=post,
+        hostname=hostname.replace(" ", "-").lower()
+    )
     return newHostname
 
 if __name__ == '__main__':


### PR DESCRIPTION
Android Devices typically get overly readable hostnames in tailscale which results in invalid DNS hostnames if used verbatim.

For instance my tablet was named "Mi Pad 4".
This fixes the DNS entries (-> mi-pad-4).
