### PR TITLE
Enable multiarch builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: latest
+          install: true
+          use: true
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -59,3 +72,12 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: |-
+            linux/amd64,
+            linux/arm/v5,
+            linux/arm/v7,
+            linux/arm64/v8,
+            linux/386,
+            linux/mips64le,
+            linux/ppc64le,
+            linux/s390x


### PR DESCRIPTION
Currently the image is only built for amd64, this PR builds images for all the other platforms that `python:3.8` supports.

See https://github.com/pschmitt/tailscale-cloudflare-dnssync/pkgs/container/tailscale-cloudflare-dnssync if you wonder what this PR ends up creating.
