### PR TITLE
Add tailscale Oauth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cf-domain=<cloudflare target zone>
 #cf-sub=<subdomain to use, optional>
 ts-key=<tailscale api key>
 ts-tailnet=<tailnet>
+#ts-clientid=<oauth clientid, optional>
+#ts-clientsecret=<oauth clientsecret, optional>
 #prefix=<prefix for dns records, optional>
 #postfix=<postfix for dns records, optional>
 ```
@@ -38,6 +40,10 @@ secrets:
     file: "./cloudflare-key.txt"
   ts-key:
     file: "./tailscale-key.txt"
+  ts-clientid:
+    file: "./tailscale-clientid.txt"
+  ts-clientsecret:
+    file: "./tailscale-clientsecret.txt"
 
 services:
   cloudflare-dns-sync:
@@ -68,6 +74,11 @@ Resource | include - specific zone - <your zone>
 ```
 
 ### Tailscale
+
+#### API Key
 1. Login to Tailscale website
 2. Create API key at: https://login.tailscale.com/admin/settings/authkeys
 
+#### Oauth
+1. Login to Tailscale website
+2. Create Oauth client at: https://login.tailscale.com/admin/settings/oauth with Devices Read permission

--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ version: "3"
 secrets:
   cf-key:
     file: "./cloudflare-key.txt"
+  # either, use ts-key for an api key or ts-clientid and ts-clientsecret for oauth
   ts-key:
     file: "./tailscale-key.txt"
   ts-clientid:
-    file: "./tailscale-clientid.txt"
+    file: "./tailscale-clientid.txt" 
   ts-clientsecret:
     file: "./tailscale-clientsecret.txt"
 
@@ -79,6 +80,6 @@ Resource | include - specific zone - <your zone>
 1. Login to Tailscale website
 2. Create API key at: https://login.tailscale.com/admin/settings/authkeys
 
-#### Oauth
+#### OAuth
 1. Login to Tailscale website
-2. Create Oauth client at: https://login.tailscale.com/admin/settings/oauth with Devices Read permission
+2. Create OAuth client at: https://login.tailscale.com/admin/settings/oauth with Devices Read permission

--- a/app/app.py
+++ b/app/app.py
@@ -14,7 +14,7 @@ def main():
     config = getConfig()
     cf_ZoneId = getZoneId(config['cf-key'], config['cf-domain'])
     cf_recordes = getZoneRecords(config['cf-key'], config['cf-domain'], zoneId=cf_ZoneId)
-    ts_records = getTailscaleDevice(config['ts-key'], config['ts-tailnet'])
+    ts_records = getTailscaleDevice(config['ts-key'], config['ts-clientid'], config['ts-clientsecret'], config['ts-tailnet'])
 
     records_typemap = {
         4: 'A',

--- a/app/config.py
+++ b/app/config.py
@@ -3,8 +3,9 @@ import os.path
 from sys import path
 from termcolor import cprint
 
-keysToImport = ['cf-key', 'cf-domain', 'ts-key', 'ts-tailnet']
-keysOptional = ['cf-sub', 'prefix', 'postfix']
+keysToImport = ['cf-key', 'cf-domain', 'ts-tailnet']
+# maybe ts-client-id & ts-client-secret are better for names ?
+keysOptional = ['cf-sub', 'prefix', 'postfix', 'ts-key', 'ts-clientid', 'ts-clientsecret']
 
 def importkey(name, optional=False):
     key = name
@@ -52,6 +53,9 @@ def getConfig():
         static[key] = importkey(key)
     for key in keysOptional:
         static[key] = importkey(key, True)
+    if not static['ts-key'] and not (static['ts-clientid'] and static['ts-clientsecret']):
+        cprint("ERROR: mandatory tailscale configuration not found: ts-key or ts-clientid/ts-clientsecret missing", "red")
+        exit(1)
     return static
 
 if __name__ == '__main__':

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,3 +5,5 @@ ipaddress==1.0.23
 requests==2.31.0
 termcolor==2.3.0
 urllib3==2.0.7
+requests-oauthlib==2.0.0
+oauthlib==3.2.2

--- a/app/tailscale.py
+++ b/app/tailscale.py
@@ -1,10 +1,15 @@
 import requests, json
 import ipaddress
 from requests.auth import HTTPBasicAuth
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
 from termcolor import colored
 
 ### Get Data
-def getTailscaleDevice(apikey, tailnet):
+def getTailscaleDevice(apikey, clientid, clientsecret, tailnet):
+    if clientid and clientsecret:
+        token = OAuth2Session(client=BackendApplicationClient(client_id=clientid)).fetch_token(token_url='https://api.tailscale.com/api/v2/oauth/token', client_id=clientid, client_secret=clientsecret)
+        apikey = token["access_token"]
     url = "https://api.tailscale.com/api/v2/tailnet/{tailnet}/devices".format(tailnet=tailnet)
     payload={}
     headers = {


### PR DESCRIPTION
This allows us to not have to worry about api key expiring after 90 days (solves  #18)
This modification works on my server but i did not test it with an api key for any regression
Readme might need to be improved a bit since i did not do a great job when modifying it
 
this could be improve by making tailnet an optional config since tailscale's doc mentions that when using oauth, tailnet isn't required ([link](https://tailscale.com/kb/1215/oauth-clients))
> When you use an access token to make an API call, you can optionally use the value - as the tailnet name—you do not need to specify the tailnet name.